### PR TITLE
Fix README install heading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ I hope this module helps you python programing in your lap-top PC.
 Quickstart
 ----------
 
-Install cachelite::
+Install aliasdict::
 
     pip install aliasdict
 


### PR DESCRIPTION
## Summary
- correct the install section heading in README.rst

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886dd73e3088320a7b57883da20d41e