### PR TITLE
Add uncompressed values test and fix bug

### DIFF
--- a/aliasdict/aliasdict.py
+++ b/aliasdict/aliasdict.py
@@ -57,7 +57,8 @@ class GZDict:
             for k in self.keys():
                 yield self.__getitem__(k)
         else:
-            self._data.values()
+            for v in self._data.values():
+                yield v
 
     def items(self):
         for k in self._data:

--- a/tests/test_aliasdict.py
+++ b/tests/test_aliasdict.py
@@ -36,7 +36,7 @@ class TestAliasDict(TestCase):
         e["key_a"] = "value_a"
         self.assertEqual(1, len(e))
 
-    def test_composite_key(self):
+    def test_len_single_key(self):
         e = AliasDict()
         e["key_a"] = "value_a"
         self.assertEqual(1, len(e))
@@ -153,4 +153,12 @@ class TestAliasDict(TestCase):
             check_values.remove(v)
 
         self.assertEqual(set(), check_values )
+
+    def test_values_uncompressed(self):
+        ad = AliasDict(compress=False)
+        ad["k1"] = "v1"
+        ad["k2"] = "v2"
+        ad["k3"] = "v3"
+
+        self.assertEqual({"v1", "v2", "v3"}, set(ad.values()))
 


### PR DESCRIPTION
## Summary
- rename the duplicate `test_composite_key` to `test_len_single_key`
- add `test_values_uncompressed` for verifying values iteration when not compressing
- fix `AliasDict.values` to yield values in uncompressed mode

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886dd83c1c88320b00a54bb18b96bbe