### PR TITLE
Fix return in GZDict.values

### DIFF
--- a/aliasdict/aliasdict.py
+++ b/aliasdict/aliasdict.py
@@ -57,7 +57,7 @@ class GZDict:
             for k in self.keys():
                 yield self.__getitem__(k)
         else:
-            self._data.values()
+            return self._data.values()
 
     def items(self):
         for k in self._data:


### PR DESCRIPTION
## Summary
- ensure `GZDict.values` returns dict values when not compressed

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886dd7eac908320a44ceca23bb0a5c4